### PR TITLE
Use HTTPS URLs for Submodules Instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "aws-iot-device-sdk-embedded-C"]
 	path = aws-iot-device-sdk-embedded-C
-	url = git@github.com:spindance/aws-iot-device-sdk-embedded-C.git
+	url = https://github.com/spindance/aws-iot-device-sdk-embedded-C.git


### PR DESCRIPTION
# Motivation for Change

Because this repo is pulled in by third-party/customer projects, it makes more sense for the submodule to utilize the HTTPS URL instead of the SSH. This will allow customers to pull in this repo as a submodule without needing public/private keys to establish an SSH connection. 

# Description of Change

- Changed the submodule URLs to be HTTPS instead of SSH

# How has this been tested?

- [x] Submodules are updated as per usual
- [x] Code builds as expected
